### PR TITLE
Fixed configuring associations

### DIFF
--- a/src/ObjectInfo/DoctrineORMInfo.php
+++ b/src/ObjectInfo/DoctrineORMInfo.php
@@ -62,7 +62,7 @@ class DoctrineORMInfo
         $assocsConfigs = [];
 
         foreach ($assocNames as $assocName) {
-            if (!$metadata->isAssociationInverseSide($assocName)) {
+            if ($metadata->isAssociationInverseSide($assocName)) {
                 continue;
             }
 


### PR DESCRIPTION
## Changelog

```markdown
### Fixed
- Fixed showing fields for *-to-One associations
```

## Subject

Negation seems to be put in that `if` by mistake. It prevents form from showing fields for *-to-One associations. And when you define those fields, you get an exception "Field(s) ... doesn't exist in ClassName", because those are not considered valid fields by `DoctrineORMManipulator`.