### PR TITLE
Respect user's form config

### DIFF
--- a/src/Form/Manipulator/DoctrineORMManipulator.php
+++ b/src/Form/Manipulator/DoctrineORMManipulator.php
@@ -56,15 +56,13 @@ class DoctrineORMManipulator implements FormManipulatorInterface
 
             // If display undesired, remove
             if (isset($formFieldConfig['display']) && (false === $formFieldConfig['display'])) {
-                unset($validObjectFieldsConfig[$formFieldName]);
+                unset($formOptions['fields'][$formFieldName]);
                 continue;
             }
-
-            // Override with formFieldsConfig priority
-            $validObjectFieldsConfig[$formFieldName] = $formFieldConfig + $validObjectFieldsConfig[$formFieldName];
         }
+        $formOptions['fields'] += $validObjectFieldsConfig;
 
-        return $validObjectFieldsConfig;
+        return $formOptions['fields'];
     }
 
     private function getDataClass(FormInterface $form): string

--- a/src/Form/Manipulator/DoctrineORMManipulator.php
+++ b/src/Form/Manipulator/DoctrineORMManipulator.php
@@ -59,6 +59,10 @@ class DoctrineORMManipulator implements FormManipulatorInterface
                 unset($formOptions['fields'][$formFieldName]);
                 continue;
             }
+
+            if ([] === $formFieldConfig) {
+                $formOptions['fields'][$formFieldName] = $validObjectFieldsConfig[$formFieldName];
+            }
         }
         $formOptions['fields'] += $validObjectFieldsConfig;
 


### PR DESCRIPTION
## Changelog

```markdown
### Fixed
- Fixed a bug where user-configured form fields order was not respected by AutoFormType
### Changed
- AutoFormType should not override or append automatically generated configs to manually configured fields
```

## Subject

I'm addressing 2 issues which I experienced when upgrading to TranslationFormBundle v3, which now requires this bundle. I believe these issues are going to affect anyone who is upgrading to v3, because AutoFormBundle changed translations form behaviour a lot and does not provide at the moment enough control over generated forms when it's needed.

1. Fields order configured by user is not respected. It renders fields in order as they are extracted from Doctrine metadata. This PR fixes it by appending automatically generated configs to `$formOptions['fields']` and not vice-versa.
2. Fields which already have user-defined config get automatically generated config appended, which is undesired and leads to bugs and exceptions in some cases, because of incorrect config. There is no way to guarantee that automatic config is going to be compatible with user-defined and no control to disable that behaviour. In my opinion the only cases when automatic field config should be allowed are
- field not defined by user and is automatically added
- field is defined by user but with no custom config (empty array), which means that field is defined for ordering purpose.
Current behaviour is quite harmful on associations fields, where it appends some field configs. It causes issues with packages from Sonata project, in particular when using `ModelListType` fields. However I believe I may cause issues with a number of other use cases, when user doesn't want that automatic config appended.
The changes in this PR implement suggested behaviour to respect user-defined field config.