### PR TITLE
Fixing "lint:container" failure

### DIFF
--- a/src/Resources/config/object_info.xml
+++ b/src/Resources/config/object_info.xml
@@ -7,7 +7,7 @@
     <services>
         <defaults public="false" />
 
-        <service id="a2lix_auto_form.doctrine.metadata_factory" class="Doctrine\Common\Persistence\Mapping\ClassMetadataFactory">
+        <service id="a2lix_auto_form.doctrine.metadata_factory" class="Doctrine\Persistence\Mapping\ClassMetadataFactory">
             <factory service="doctrine.orm.default_entity_manager" method="getMetadataFactory" />
         </service>
 


### PR DESCRIPTION
Hi, I found that running `bin/console lint:container` in my project (Symfony 5.1) fires an error:
```
[ERROR] Invalid definition for service                                         
         "a2lix_auto_form.form.manipulator.doctrine_orm_manipulator": argument 1
         of "A2lix\AutoFormBundle\ObjectInfo\DoctrineORMInfo::__construct"      
         accepts "Doctrine\Persistence\Mapping\ClassMetadataFactory",           
         "Doctrine\Common\Persistence\Mapping\ClassMetadataFactory" passed.
```

I tried to fix it according to the error suggestion. `Doctrine\Common\Persistence\*` as been moved to it's own package since [v2.9.0](https://github.com/doctrine/common/releases/tag/v2.9.0) so `Doctrine\Common\Persistence\Mapping\ClassMetadataFactory` is deprecated in favor of `Doctrine\Persistence\Mapping\ClassMetadataFactory`.

I hope this is the right fix.

Thank you for your time.