### PR TITLE
Fix: error if translation contains ManyToMany including 'inversedBy'

### DIFF
--- a/src/ObjectInfo/DoctrineORMInfo.php
+++ b/src/ObjectInfo/DoctrineORMInfo.php
@@ -64,6 +64,7 @@ class DoctrineORMInfo
             $associationMapping = $metadata->getAssociationMapping($assocName);
 
             if (isset($associationMapping['inversedBy'])) {
+                $assocsConfigs[$assocName] = [];
                 continue;
             }
 


### PR DESCRIPTION
When I have used a CollectionType inside TranslationType and association included 'inversedBy', it caused an error about non-existent field. This solution worked for me and did not break anything else.