### PR TITLE
Multiple entity managers

### DIFF
--- a/src/ObjectInfo/DoctrineORMInfo.php
+++ b/src/ObjectInfo/DoctrineORMInfo.php
@@ -98,7 +98,7 @@ class DoctrineORMInfo
     {
         $em = $this->managerRegistry->getManagerForClass($class);
         $classMetadataFactory = $em->getMetadataFactory();
-        return $classMetadataFactory->getMetadataFor($class);
 
+        return $classMetadataFactory->getMetadataFor($class);
     }
 }

--- a/src/Resources/config/object_info.xml
+++ b/src/Resources/config/object_info.xml
@@ -7,12 +7,8 @@
     <services>
         <defaults public="false" />
 
-        <service id="a2lix_auto_form.doctrine.metadata_factory" class="Doctrine\Persistence\Mapping\ClassMetadataFactory">
-            <factory service="doctrine.orm.default_entity_manager" method="getMetadataFactory" />
-        </service>
-
         <service id="a2lix_auto_form.object_info.doctrine_orm_info" class="A2lix\AutoFormBundle\ObjectInfo\DoctrineORMInfo">
-            <argument type="service" id="a2lix_auto_form.doctrine.metadata_factory" />
+            <argument type="service" id="doctrine" />
         </service>
     </services>
 </container>

--- a/tests/Fixtures/Entity/Media.php
+++ b/tests/Fixtures/Entity/Media.php
@@ -47,7 +47,7 @@ class Media
         return $this->id;
     }
 
-    public function getProduct(): Product
+    public function getProduct(): ?Product
     {
         return $this->product;
     }

--- a/tests/Form/Type/AutoFormTypeAdvancedTest.php
+++ b/tests/Form/Type/AutoFormTypeAdvancedTest.php
@@ -81,9 +81,9 @@ final class AutoFormTypeAdvancedTest extends TypeTestCase
         ];
 
         $form->submit($formData);
-        static::assertTrue($form->isSynchronized());
-        static::assertEquals($product, $form->getData());
-        static::assertEquals('URL/URI', $form->get('url')->getConfig()->getOptions()['label']);
+        self::assertTrue($form->isSynchronized());
+        self::assertEquals($product, $form->getData());
+        self::assertEquals('URL/URI', $form->get('url')->getConfig()->getOptions()['label']);
 
         return $product;
     }
@@ -132,9 +132,9 @@ final class AutoFormTypeAdvancedTest extends TypeTestCase
         ];
 
         $form->submit($formData);
-        static::assertTrue($form->isSynchronized());
-        static::assertEquals($product, $form->getData());
-        static::assertEquals('blue', $form->get('color')->getData());
+        self::assertTrue($form->isSynchronized());
+        self::assertEquals($product, $form->getData());
+        self::assertEquals('blue', $form->get('color')->getData());
 
         return $product;
     }

--- a/tests/Form/Type/AutoFormTypeSimpleTest.php
+++ b/tests/Form/Type/AutoFormTypeSimpleTest.php
@@ -32,11 +32,11 @@ final class AutoFormTypeSimpleTest extends TypeTestCase
             ->getForm()
         ;
 
-        static::assertEquals(['create', 'title', 'description', 'url', 'mainMedia', 'medias'], array_keys($form->all()), 'Fields should matches Product fields');
+        self::assertEquals(['create', 'title', 'description', 'url', 'mainMedia', 'medias'], array_keys($form->all()), 'Fields should matches Product fields');
 
         $mediasFormOptions = $form->get('medias')->getConfig()->getOptions();
-        static::assertEquals(AutoFormType::class, $mediasFormOptions['entry_type'], 'Media type should be an AutoType');
-        static::assertEquals(Media::class, $mediasFormOptions['entry_options']['data_class'], 'Media should have its right data_class');
+        self::assertEquals(AutoFormType::class, $mediasFormOptions['entry_type'], 'Media type should be an AutoType');
+        self::assertEquals(Media::class, $mediasFormOptions['entry_options']['data_class'], 'Media should have its right data_class');
     }
 
     public function testCreationForm(): Product
@@ -76,8 +76,8 @@ final class AutoFormTypeSimpleTest extends TypeTestCase
         ];
 
         $form->submit($formData);
-        static::assertTrue($form->isSynchronized());
-        static::assertEquals($product, $form->getData());
+        self::assertTrue($form->isSynchronized());
+        self::assertEquals($product, $form->getData());
 
         return $product;
     }
@@ -110,14 +110,14 @@ final class AutoFormTypeSimpleTest extends TypeTestCase
         ;
 
         $form->submit($formData);
-        static::assertTrue($form->isSynchronized());
-        static::assertEquals($product, $form->getData());
+        self::assertTrue($form->isSynchronized());
+        self::assertEquals($product, $form->getData());
 
         $view = $form->createView();
         $children = $view->children;
 
         foreach (array_keys($formData) as $key) {
-            static::assertArrayHasKey($key, $children);
+            self::assertArrayHasKey($key, $children);
         }
     }
 

--- a/tests/Form/TypeTestCase.php
+++ b/tests/Form/TypeTestCase.php
@@ -19,6 +19,7 @@ use A2lix\AutoFormBundle\Form\Type\AutoFormType;
 use A2lix\AutoFormBundle\ObjectInfo\DoctrineORMInfo;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Tools\Setup;
+use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Form\Extension\Validator\Type\FormTypeValidatorExtension;
 use Symfony\Component\Form\Extension\Validator\ValidatorTypeGuesser;
@@ -64,7 +65,10 @@ abstract class TypeTestCase extends BaseTypeTestCase
 
         $config = Setup::createAnnotationMetadataConfiguration([__DIR__.'/../Fixtures/Entity'], true, null, null, false);
         $entityManager = EntityManager::create(['driver' => 'pdo_sqlite'], $config);
-        $doctrineORMInfo = new DoctrineORMInfo($entityManager->getMetadataFactory());
+
+        $managerRegistry = $this->createMock(ManagerRegistry::class);
+        $managerRegistry->method('getManagerForClass')->willReturn($entityManager);
+        $doctrineORMInfo = new DoctrineORMInfo($managerRegistry);
 
         return $this->doctrineORMManipulator = new DoctrineORMManipulator($doctrineORMInfo, ['id', 'locale', 'translatable']);
     }


### PR DESCRIPTION
This PR enhances the DoctrineORMInfo class in the A2lix\AutoFormBundle to better support applications that use multiple Doctrine entity managers.

Previously, this class was directly creating an EntityManager which can cause compatibility issues when the application requires different EntityManager instances for different classes.

Now, the DoctrineORMInfo service utilizes the  ManagerRegistry service. The ManagerRegistry service is used to retrieve the appropriate EntityManager for a given class. This allows for better compatibility with applications that use multiple entity managers.

The changes include:

    Replaced the ClassMetadataFactory with the ManagerRegistry in DoctrineORMInfo.
    Updated the methods getFieldsConfig, getAssociationTargetClass, getAssocsConfig and getMetadata to use the new manager registry.
    Updated the DoctrineORMInfo service definition.
    Updated test cases to reflect these changes.

The PR addresses the problem raised in issue #16 .